### PR TITLE
Fixed build of jscience.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Palladio ThirdParty Wrapper
+The ThirdParty Wrapper project wraps dependencies that are not available via an Eclipse P2 update site.
+
+Please note that this wrapper is deprecated.
+
+## Support
+For support
+* visit our [issue tracking system](https://palladio-simulator.com/jira)
+* contact us via our [mailing list](https://lists.ira.uni-karlsruhe.de/mailman/listinfo/palladio-dev)
+
+For professional support, please fill in our [contact form](http://www.palladio-simulator.com/about_palladio/support/).

--- a/bundles/org.jscience/build.properties
+++ b/bundles/org.jscience/build.properties
@@ -3,10 +3,8 @@ bin.includes = META-INF/,\
                .,\
                lib/,\
                about_files/,\
-               about.html,\
-               bin/
-src.includes = bin/,\
-               doc/,\
+               about.html
+src.includes = doc/,\
                index.html,\
                lib/
 jars.compile.order = .,\


### PR DESCRIPTION
I did not recognize the wrong entry in the build.properties the last time i built because I forgot to delete the `bin` folder in my local installation... The PR should fix the build.