### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,9 +5,4 @@
 		<artifactId>tycho-build</artifactId>
 		<version>2.7.5</version>
 	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
-	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.9.0</version>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.thirdpartywrapper</groupId>
 	<artifactId>parent</artifactId>	
@@ -18,6 +18,10 @@
 		<module>features</module>
 		<module>releng</module>
 	</modules>
+
+	<properties>
+		<targetPlatform.relativePath>releng/org.palladiosimulator.thirdpartywrapper.targetplatform/tp.target</targetPlatform.relativePath>
+	</properties>
 
 	<build>
 		<plugins>

--- a/releng/org.palladiosimulator.thirdpartywrapper.targetplatform/.project
+++ b/releng/org.palladiosimulator.thirdpartywrapper.targetplatform/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.palladiosimulator.thirdpartywrapper.targetplatform</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/org.palladiosimulator.thirdpartywrapper.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.thirdpartywrapper.targetplatform/tp.target
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="org.palladiosimulator.thirdpartywrapper Target Platform" sequenceNumber="1">
+	<locations>
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
+	</locations>
+</target>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.9.0` to the new parent POM version `0.10.0`  
- Locally verified build success  

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.9.0` to `0.10.0`
  - Added property `targetPlatform.relativePath` and set its value to the path to `tp.target`
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`
- In the target platform `tp.target`:
  - Newly created `tp.target` and inserted `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM